### PR TITLE
Vercel環境のデプロイ設定を追加

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## なぜこの変更が必要か（背景）

Vercel環境へのSPAデプロイにおいて、クライアントサイドルーティングのフォールバック設定が必要。
React Routerなどの画面遷移で直接URLアクセスした際に404にならないようにする。

## 何を変えたか（概要）

`vercel.json`を新規作成し、SPAリライト設定を追加。

## 変更内容

- `vercel.json` を新規追加
- 全ルートを `/index.html` にリライトするSPAフォールバック設定
- JSON Schema参照を設定（エディタ補完用）

## レビューのポイント

- 特に見てほしい箇所: リライトルールの妥当性
- 判断を仰ぎたい点: 特になし（最小構成のため）

## 確認済み事項

- [x] ローカルで `pnpm build` 通過
- [x] Vercelへのデプロイ成功（Production URLで動作確認済み）
- [x] GitHub連携による自動デプロイも設定済み
