### PR TITLE
ストア分割・永続化 + UI操作改善

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,16 @@
-import { useState } from "react";
 import { TimerPage } from "@/pages/timer-page";
-import { usePresetStore } from "@/stores/preset-store";
-
-/**
- * 初期プリセットIDを決定する
- *
- * プリセットストアの最初のプリセットIDを返す。
- * プリセットが存在しない場合は空文字列を返す（通常は到達しない）。
- */
-const resolveInitialPresetId = (): string => {
-  const firstPreset = usePresetStore.getState().presets[0];
-  return firstPreset?.id ?? "";
-};
+import { useAppStore } from "@/stores/app-store";
 
 /**
  * アプリケーションのルートコンポーネント
  *
  * タイマー画面を唯一のメイン画面として表示する。
  * プリセットの切り替えはボトムドロワーから行い、画面遷移は発生しない。
+ * 選択中のプリセットIDは app-store で localStorage に永続化される。
  */
 export const App = () => {
-  const [currentPresetId, setCurrentPresetId] = useState(resolveInitialPresetId);
+  const currentPresetId = useAppStore((s) => s.currentPresetId);
+  const setCurrentPresetId = useAppStore((s) => s.setCurrentPresetId);
 
   return (
     <TimerPage

--- a/src/components/bpm-control.tsx
+++ b/src/components/bpm-control.tsx
@@ -10,22 +10,21 @@ import {
   setMetronomeBpm,
   setMetronomeVolume,
 } from "@/audio/metronome-engine";
+import { useBpmStore } from "@/stores/bpm-store";
 
 /** P5モーション: ボタン共通のアニメーションクラス */
 const MOTION_CLASS =
   "transition-all duration-200 hover:scale-110 active:scale-90" as const;
-
-/** デフォルトBPM */
-const DEFAULT_BPM = 160;
-
-/** デフォルト音量（パーセンテージ） */
-const DEFAULT_VOLUME = 50;
 
 /**
  * BPMメトロノームコントロールコンポーネント
  *
  * 片手操作でBPM（140〜200）と音量（0〜100%）を調節しながら
  * メトロノームのON/OFFを制御する。
+ * BPM・音量は bpm-store で localStorage に永続化される。
+ *
+ * **注意**: 再生状態（isPlaying）はブラウザの自動再生制限により
+ * 永続化せず、常に停止状態から開始する。
  *
  * **UXベストプラクティス**:
  * - フィードバック: ON/OFF状態が色で明確に識別可能
@@ -34,8 +33,10 @@ const DEFAULT_VOLUME = 50;
  */
 export const BpmControl = memo(function BpmControl() {
   const [isPlaying, setIsPlaying] = useState(false);
-  const [bpm, setBpm] = useState(DEFAULT_BPM);
-  const [volume, setVolume] = useState(DEFAULT_VOLUME);
+  const bpm = useBpmStore((s) => s.bpm);
+  const volume = useBpmStore((s) => s.volume);
+  const setBpm = useBpmStore((s) => s.setBpm);
+  const setVolume = useBpmStore((s) => s.setVolume);
 
   /** メトロノームのON/OFF切替 */
   const handleToggle = useCallback(async () => {
@@ -59,7 +60,7 @@ export const BpmControl = memo(function BpmControl() {
         setMetronomeBpm(clamped);
       }
     },
-    [isPlaying],
+    [isPlaying, setBpm],
   );
 
   /** 音量変更（リアルタイム反映） */
@@ -71,7 +72,7 @@ export const BpmControl = memo(function BpmControl() {
         setMetronomeVolume(clamped);
       }
     },
-    [isPlaying],
+    [isPlaying, setVolume],
   );
 
   return (

--- a/src/components/preset-drawer.tsx
+++ b/src/components/preset-drawer.tsx
@@ -1,8 +1,12 @@
-import { useState } from "react";
-import { X } from "lucide-react";
+import { memo } from "react";
+import { X, ListMusic } from "lucide-react";
 import { usePresetStore } from "@/stores/preset-store";
-import { useTimerStore } from "@/stores/timer-store";
-import { PresetSchema, formatPhaseSummary } from "@/schemas/timer";
+import { useDrawerStore } from "@/stores/drawer-store";
+import {
+  type Phase,
+  PresetSchema,
+  formatPhaseSummary,
+} from "@/schemas/timer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -22,6 +26,12 @@ type PresetDrawerProps = {
   readonly currentPresetId: string;
   /** プリセット選択時のコールバック */
   readonly onSelectPreset: (presetId: string) => void;
+  /** 現在画面に表示中のフェーズ配列（idle時はローカル編集値、実行時はストア値） */
+  readonly currentPhases: readonly Phase[];
+  /** 現在画面に表示中の総ラウンド数 */
+  readonly currentTotalRounds: number;
+  /** 現在画面に表示中の準備フェーズ秒数 */
+  readonly currentPrepareSec: number;
 };
 
 /** P5モーション: ボタン共通のアニメーションクラス */
@@ -29,19 +39,23 @@ const MOTION_CLASS =
   "transition-all duration-200 hover:scale-105 active:scale-95" as const;
 
 /**
- * タイマーストアの現在の設定からプリセットを生成する
+ * 現在の表示設定からプリセットを生成する
  *
  * ステッパーで調整済みの phases / totalRounds / prepareSec を
  * プリセットスキーマに変換する。バリデーション失敗時は null を返す。
  */
-const buildPresetFromCurrentSettings = (name: string) => {
-  const { phases, totalRounds, prepareSec } = useTimerStore.getState();
+const buildPresetFromSettings = (
+  name: string,
+  phases: readonly Phase[],
+  totalRounds: number,
+  prepareSec: number,
+) => {
   const raw = {
     id: crypto.randomUUID(),
     name,
     totalRounds,
     prepareSec,
-    phases,
+    phases: [...phases],
     createdAt: Date.now(),
   };
   const result = PresetSchema.safeParse(raw);
@@ -51,30 +65,33 @@ const buildPresetFromCurrentSettings = (name: string) => {
 /**
  * プリセットドロワーコンポーネント
  *
- * ボトムドロワーでプリセット一覧を表示し、片手操作でプリセット切り替え・登録・削除を行う。
+ * 右サイドドロワーでプリセット一覧を表示し、プリセット切り替え・登録・削除を行う。
+ * ドロワーのUI状態（開閉、登録フォーム表示、入力値）は drawer-store で
+ * localStorage に永続化される。
  *
  * **OOUI原則**: プリセット（オブジェクト）を一覧表示 → タップでアクション（選択/削除）
- * **片手操作**: ドロワーは画面下部から引き上げ、親指で全操作が完結する
+ *
+ * **memo化**: 親（TimerPage）が running 中に毎秒再レンダリングされるが、
+ * このコンポーネントの props は安定しているため不要な再レンダリングを防止する。
  */
-export const PresetDrawer = ({
+export const PresetDrawer = memo(function PresetDrawer({
   currentPresetId,
   onSelectPreset,
-}: PresetDrawerProps) => {
+  currentPhases,
+  currentTotalRounds,
+  currentPrepareSec,
+}: PresetDrawerProps) {
   const presets = usePresetStore((s) => s.presets);
   const addPreset = usePresetStore((s) => s.addPreset);
   const removePreset = usePresetStore((s) => s.removePreset);
-  const phases = useTimerStore((s) => s.phases);
 
-  const [isOpen, setIsOpen] = useState(false);
-  const [isRegistering, setIsRegistering] = useState(false);
-  const [newPresetName, setNewPresetName] = useState("");
-
-  /** ドロワーを閉じて登録フォームもリセットする */
-  const closeDrawer = () => {
-    setIsOpen(false);
-    setIsRegistering(false);
-    setNewPresetName("");
-  };
+  const isOpen = useDrawerStore((s) => s.isOpen);
+  const setIsOpen = useDrawerStore((s) => s.setIsOpen);
+  const isRegistering = useDrawerStore((s) => s.isRegistering);
+  const setIsRegistering = useDrawerStore((s) => s.setIsRegistering);
+  const newPresetName = useDrawerStore((s) => s.newPresetName);
+  const setNewPresetName = useDrawerStore((s) => s.setNewPresetName);
+  const closeDrawer = useDrawerStore((s) => s.closeDrawer);
 
   /** プリセットを選択してドロワーを閉じる */
   const handleSelectPreset = (presetId: string) => {
@@ -87,7 +104,12 @@ export const PresetDrawer = ({
     const trimmed = newPresetName.trim();
     if (trimmed.length === 0) return;
 
-    const preset = buildPresetFromCurrentSettings(trimmed);
+    const preset = buildPresetFromSettings(
+      trimmed,
+      currentPhases,
+      currentTotalRounds,
+      currentPrepareSec,
+    );
     if (preset) {
       addPreset(preset);
       setIsRegistering(false);
@@ -95,27 +117,24 @@ export const PresetDrawer = ({
     }
   };
 
-  /** 登録可能かどうか（タイマーにフェーズがロードされている場合のみ） */
-  const canRegister = phases.length > 0;
+  /** 登録可能かどうか（画面にフェーズが表示されている場合のみ） */
+  const canRegister = currentPhases.length > 0;
 
   return (
-    <Drawer open={isOpen} onOpenChange={setIsOpen}>
+    <Drawer direction="right" open={isOpen} onOpenChange={setIsOpen}>
+      {/* 右端サイドタブ: 縦書きで「PRESET」表示 */}
       <DrawerTrigger asChild>
         <button
           type="button"
-          className="fixed bottom-0 left-0 right-0 z-40 flex flex-col items-center gap-1 pb-3 pt-2"
+          className="fixed right-0 top-1/2 z-40 flex -translate-y-1/2 items-center gap-1.5 rounded-l-lg border border-r-0 border-red-900/30 bg-[#0a0a0a]/90 px-1.5 py-4 backdrop-blur-sm transition-colors hover:bg-neutral-900"
           aria-label="プリセット一覧を開く"
         >
-          {/* ドラッグハンドル（片手で引き上げる視覚的ヒント） */}
-          <span className="h-1.5 w-12 rounded-full bg-neutral-600 transition-colors hover:bg-neutral-400" />
-          <span className="text-[10px] tracking-widest text-neutral-600">
-            プリセット
-          </span>
+          <ListMusic className="size-4 text-neutral-400" />
         </button>
       </DrawerTrigger>
 
       <DrawerContent className="border-red-900/30 bg-[#0a0a0a]">
-        <DrawerHeader>
+        <DrawerHeader className="text-left">
           <DrawerTitle className="text-lg font-black tracking-tighter text-white">
             プリセット
           </DrawerTitle>
@@ -124,8 +143,8 @@ export const PresetDrawer = ({
           </DrawerDescription>
         </DrawerHeader>
 
-        {/* プリセット一覧（スクロール可能） */}
-        <div className="flex max-h-[40vh] flex-col gap-2 overflow-y-auto px-4">
+        {/* プリセット一覧（縦スクロール可能、サイドドロワーなので高さをフルに使う） */}
+        <div className="flex flex-1 flex-col gap-2 overflow-y-auto px-4">
           {presets.map((preset) => {
             const isActive = preset.id === currentPresetId;
             return (
@@ -220,4 +239,4 @@ export const PresetDrawer = ({
       </DrawerContent>
     </Drawer>
   );
-};
+});

--- a/src/stores/app-store.ts
+++ b/src/stores/app-store.ts
@@ -1,0 +1,155 @@
+import { z } from "zod/v4";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { usePresetStore } from "./preset-store";
+import {
+  type PhaseType,
+  PhaseSchema,
+  MAX_TOTAL_ROUNDS,
+  MIN_PHASE_DURATION_SEC,
+  MAX_PHASE_DURATION_SEC,
+} from "@/schemas/timer";
+
+/**
+ * フェーズ秒数から初期スケールインデックスを導出する
+ *
+ * 60秒以下なら Short（0）、60秒超なら Long（1）を返す。
+ */
+const resolveScaleIndex = (durationSec: number): number => (durationSec > 60 ? 1 : 0);
+
+/**
+ * アプリストアの永続化データを検証するZodスキーマ
+ *
+ * localStorage から復元したデータが正しい構造を持つか `safeParse` で検証し、
+ * 不正データの場合はデフォルト状態にフォールバックする。
+ * 復元時、参照先プリセットが削除済みの場合もフォールバックする。
+ */
+const AppStoreSchema = z.object({
+  /** 現在選択中のプリセットID */
+  currentPresetId: z.string(),
+  /** idle 時のフェーズ編集値（ステッパーで変更済みの可能性あり） */
+  idlePhases: z.array(PhaseSchema),
+  /** idle 時のラウンド数編集値 */
+  idleTotalRounds: z.number().int().positive().max(MAX_TOTAL_ROUNDS),
+  /** WORK フェーズのスケール選択（0: Short, 1: Long） */
+  workScaleIndex: z.number().int().min(0).max(1),
+  /** REST フェーズのスケール選択（0: Short, 1: Long） */
+  restScaleIndex: z.number().int().min(0).max(1),
+});
+
+/** アプリストアの状態型 */
+type AppStoreState = z.infer<typeof AppStoreSchema>;
+
+/** アプリストアのアクション型 */
+type AppStoreActions = {
+  /**
+   * 選択中のプリセットIDを変更する
+   *
+   * プリセット切替時、idlePhases / idleTotalRounds / scaleIndex を
+   * 新しいプリセットのデフォルト値にリセットする。
+   */
+  readonly setCurrentPresetId: (id: string) => void;
+  /** idle 時のラウンド数を更新する（1〜MAX_TOTAL_ROUNDS にクランプ） */
+  readonly updateIdleTotalRounds: (newTotalRounds: number) => void;
+  /**
+   * idle 時の指定タイプのフェーズ秒数を更新する
+   *
+   * 同タイプの全フェーズの durationSec を一括更新する。
+   * MIN_PHASE_DURATION_SEC〜MAX_PHASE_DURATION_SEC にクランプ。
+   */
+  readonly updateIdlePhaseDuration: (phaseType: PhaseType, newDurationSec: number) => void;
+  /** 指定フェーズタイプのスケールインデックスを設定する（0: Short, 1: Long） */
+  readonly setScaleIndex: (phaseType: PhaseType, index: number) => void;
+};
+
+/** localStorage に保存する際のストレージキー */
+const STORAGE_KEY = "interval-timer-app" as const;
+
+/**
+ * 初期状態を決定する
+ *
+ * プリセットストアの最初のプリセットからデフォルト値を取得する。
+ * プリセットが存在しない場合はフォールバック値を返す（通常は到達しない）。
+ */
+const resolveInitialState = (): AppStoreState => {
+  const firstPreset = usePresetStore.getState().presets[0];
+  const phases = firstPreset?.phases ?? [];
+  const workDuration = phases.find((p) => p.type === "work")?.durationSec ?? MIN_PHASE_DURATION_SEC;
+  const restDuration = phases.find((p) => p.type === "rest")?.durationSec ?? MIN_PHASE_DURATION_SEC;
+  return {
+    currentPresetId: firstPreset?.id ?? "",
+    idlePhases: phases,
+    idleTotalRounds: firstPreset?.totalRounds ?? 1,
+    workScaleIndex: resolveScaleIndex(workDuration),
+    restScaleIndex: resolveScaleIndex(restDuration),
+  };
+};
+
+/**
+ * アプリケーションの画面状態を管理するストア
+ *
+ * - Zustand の `persist` ミドルウェアで localStorage に永続化
+ * - `merge` コールバックで Zod バリデーション + プリセット存在チェック
+ * - 参照先プリセットが削除済みの場合はデフォルト（先頭プリセット）にフォールバック
+ *
+ * 管理する状態:
+ * - currentPresetId: 選択中のプリセット
+ * - idlePhases / idleTotalRounds: idle 時にステッパーで編集した値
+ * - workScaleIndex / restScaleIndex: Short/Long スケールタブの選択状態
+ */
+export const useAppStore = create<AppStoreState & AppStoreActions>()(
+  persist(
+    (set, get) => ({
+      ...resolveInitialState(),
+
+      setCurrentPresetId: (id: string) => {
+        const preset = usePresetStore.getState().presets.find((p) => p.id === id);
+        const phases = preset?.phases ?? [];
+        const workDuration = phases.find((p) => p.type === "work")?.durationSec ?? MIN_PHASE_DURATION_SEC;
+        const restDuration = phases.find((p) => p.type === "rest")?.durationSec ?? MIN_PHASE_DURATION_SEC;
+        set({
+          currentPresetId: id,
+          idlePhases: phases,
+          idleTotalRounds: preset?.totalRounds ?? 1,
+          workScaleIndex: resolveScaleIndex(workDuration),
+          restScaleIndex: resolveScaleIndex(restDuration),
+        });
+      },
+
+      updateIdleTotalRounds: (newTotalRounds: number) => {
+        const clamped = Math.max(1, Math.min(newTotalRounds, MAX_TOTAL_ROUNDS));
+        set({ idleTotalRounds: clamped });
+      },
+
+      updateIdlePhaseDuration: (phaseType: PhaseType, newDurationSec: number) => {
+        const clamped = Math.max(MIN_PHASE_DURATION_SEC, Math.min(newDurationSec, MAX_PHASE_DURATION_SEC));
+        const { idlePhases } = get();
+        set({
+          idlePhases: idlePhases.map((p) =>
+            p.type === phaseType ? { ...p, durationSec: clamped } : p,
+          ),
+        });
+      },
+
+      setScaleIndex: (phaseType: PhaseType, index: number) => {
+        if (phaseType === "work") {
+          set({ workScaleIndex: index });
+        } else {
+          set({ restScaleIndex: index });
+        }
+      },
+    }),
+    {
+      name: STORAGE_KEY,
+      merge: (persisted, current) => {
+        const parsed = AppStoreSchema.safeParse(persisted);
+        if (!parsed.success) return current;
+
+        // 復元されたプリセットIDがまだ存在するか確認
+        const presets = usePresetStore.getState().presets;
+        const exists = presets.some((p) => p.id === parsed.data.currentPresetId);
+        return exists ? { ...current, ...parsed.data } : current;
+      },
+    },
+  ),
+);

--- a/src/stores/bpm-store.ts
+++ b/src/stores/bpm-store.ts
@@ -1,0 +1,73 @@
+import { z } from "zod/v4";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { MIN_BPM, MAX_BPM } from "@/audio/metronome-engine";
+
+/** デフォルトBPM */
+const DEFAULT_BPM = 160;
+
+/** デフォルト音量（パーセンテージ） */
+const DEFAULT_VOLUME = 50;
+
+/**
+ * BPMストアの永続化データを検証するZodスキーマ
+ *
+ * localStorage から復元したデータが正しい構造を持つか `safeParse` で検証し、
+ * 不正データ（範囲外の値を含む）の場合はデフォルト状態にフォールバックする。
+ */
+const BpmStoreSchema = z.object({
+  /** メトロノームのBPM（140〜200） */
+  bpm: z.number().min(MIN_BPM).max(MAX_BPM),
+  /** メトロノームの音量（0〜100%） */
+  volume: z.number().min(0).max(100),
+});
+
+/** BPMストアの状態型 */
+type BpmStoreState = z.infer<typeof BpmStoreSchema>;
+
+/** BPMストアのアクション型 */
+type BpmStoreActions = {
+  /** BPMを設定する（MIN_BPM〜MAX_BPMにクランプ） */
+  readonly setBpm: (bpm: number) => void;
+  /** 音量を設定する（0〜100にクランプ） */
+  readonly setVolume: (volume: number) => void;
+};
+
+/** localStorage に保存する際のストレージキー */
+const STORAGE_KEY = "interval-timer-bpm" as const;
+
+/**
+ * メトロノームのBPM・音量設定を管理するストア
+ *
+ * - Zustand の `persist` ミドルウェアで localStorage に永続化
+ * - `merge` コールバックで Zod バリデーション（範囲外はデフォルトにフォールバック）
+ * - アクション内でも値をクランプし、不正値の書き込みを防止
+ *
+ * **注意**: メトロノームの再生状態（isPlaying）はブラウザの自動再生制限により
+ * 永続化せず、コンポーネントローカルの useState で管理する。
+ */
+export const useBpmStore = create<BpmStoreState & BpmStoreActions>()(
+  persist(
+    (set) => ({
+      bpm: DEFAULT_BPM,
+      volume: DEFAULT_VOLUME,
+
+      setBpm: (bpm: number) => {
+        const clamped = Math.max(MIN_BPM, Math.min(bpm, MAX_BPM));
+        set({ bpm: clamped });
+      },
+
+      setVolume: (volume: number) => {
+        const clamped = Math.max(0, Math.min(volume, 100));
+        set({ volume: clamped });
+      },
+    }),
+    {
+      name: STORAGE_KEY,
+      merge: (persisted, current) => {
+        const parsed = BpmStoreSchema.safeParse(persisted);
+        return parsed.success ? { ...current, ...parsed.data } : current;
+      },
+    },
+  ),
+);

--- a/src/stores/drawer-store.ts
+++ b/src/stores/drawer-store.ts
@@ -1,0 +1,65 @@
+import { z } from "zod/v4";
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/**
+ * ドロワーストアの永続化データを検証するZodスキーマ
+ *
+ * localStorage から復元したデータが正しい構造を持つか `safeParse` で検証し、
+ * 不正データの場合はデフォルト状態（全て閉じた状態）にフォールバックする。
+ */
+const DrawerStoreSchema = z.object({
+  /** ドロワーの開閉状態 */
+  isOpen: z.boolean(),
+  /** プリセット登録フォームの表示状態 */
+  isRegistering: z.boolean(),
+  /** 新規プリセット名の入力値 */
+  newPresetName: z.string(),
+});
+
+/** ドロワーストアの状態型 */
+type DrawerStoreState = z.infer<typeof DrawerStoreSchema>;
+
+/** ドロワーストアのアクション型 */
+type DrawerStoreActions = {
+  /** ドロワーの開閉状態を設定する */
+  readonly setIsOpen: (open: boolean) => void;
+  /** 登録フォームの表示状態を設定する */
+  readonly setIsRegistering: (registering: boolean) => void;
+  /** 新規プリセット名を設定する */
+  readonly setNewPresetName: (name: string) => void;
+  /** ドロワーを閉じて登録フォームもリセットする */
+  readonly closeDrawer: () => void;
+};
+
+/** localStorage に保存する際のストレージキー */
+const STORAGE_KEY = "interval-timer-drawer" as const;
+
+/**
+ * プリセットドロワーのUI状態を管理するストア
+ *
+ * - Zustand の `persist` ミドルウェアで localStorage に永続化
+ * - `merge` コールバックで Zod バリデーション
+ * - `closeDrawer` アクションで3つの状態を一括リセット（アトミック更新）
+ */
+export const useDrawerStore = create<DrawerStoreState & DrawerStoreActions>()(
+  persist(
+    (set) => ({
+      isOpen: false,
+      isRegistering: false,
+      newPresetName: "",
+
+      setIsOpen: (open: boolean) => set({ isOpen: open }),
+      setIsRegistering: (registering: boolean) => set({ isRegistering: registering }),
+      setNewPresetName: (name: string) => set({ newPresetName: name }),
+      closeDrawer: () => set({ isOpen: false, isRegistering: false, newPresetName: "" }),
+    }),
+    {
+      name: STORAGE_KEY,
+      merge: (persisted, current) => {
+        const parsed = DrawerStoreSchema.safeParse(persisted);
+        return parsed.success ? { ...current, ...parsed.data } : current;
+      },
+    },
+  ),
+);


### PR DESCRIPTION
## なぜこの変更が必要か（背景）

コンポーネントローカルの useState で管理していたBPM設定・ドロワー状態・idle時の編集値が、
ページリロードのたびにリセットされていた。また、スケールの切替操作がスワイプジェスチャーで、
スライダー操作と水平方向のジェスチャーが競合する問題があった。

## 何を変えたか（概要）

Zustand ストアを3つ新規追加（app-store / bpm-store / drawer-store）し、
全ストアに persist ミドルウェア + Zod バリデーションによる localStorage 永続化を追加。
UIはスワイプ → タブ切替、ボトムドロワー → 右サイドドロワーに変更。

## 変更内容

- **app-store**: 選択プリセットID / idle時フェーズ編集値 / スケール選択を一元管理
- **bpm-store**: メトロノームのBPM・音量を永続化（再生状態は除外）
- **drawer-store**: ドロワー開閉・登録フォーム状態を永続化
- **timer-store**: persist ミドルウェア追加。復元時 running → paused に自動変更
- **phase-duration-stepper**: スワイプ → Short/Long タブ切替に変更（ジェスチャー競合を解消）
- **preset-drawer**: ボトムドロワー → 右サイドドロワー + memo化
- **timer-page**: idle時のローカルstate → app-store、ringConfig統合

## レビューのポイント

- 特に見てほしい箇所: timer-store の復元ロジック（running → paused への自動変更）
- 判断を仰ぎたい点: drawer-store の永続化は本当に必要か（UX的にリロード後もドロワーが開いたままになる）

## 確認済み事項

- [x] ローカルで動作確認
- [x] 全ストアの Zod バリデーション + フォールバック処理
- [x] 削除済みプリセット参照時のフォールバック（app-store merge）
