### PR TITLE
全画面要素のテキスト選択を無効化（モバイルUX改善）

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -117,9 +117,17 @@
 @layer base {
   * {
     @apply border-border outline-ring/50;
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
   }
   body {
     @apply bg-background text-foreground;
+  }
+  input,
+  textarea {
+    -webkit-user-select: text;
+    user-select: text;
   }
 }
 


### PR DESCRIPTION
## なぜこの変更が必要か（背景）

スマホでタイマー操作中に、意図しないテキスト選択が発生して操作の妨げになっていた。
インターバルタイマーはタップ・スワイプ中心のアプリなので、テキスト選択は不要。

## 何を変えたか（概要）

グローバルCSSで全要素のテキスト選択を無効化し、input/textareaのみ例外として選択可能にした。

## 変更内容

- `src/app.css` の `@layer base > *` に `user-select: none` / `-webkit-user-select: none` / `-webkit-touch-callout: none` を追加
- `input`, `textarea` は `user-select: text` で例外化（プリセット名入力などのフォーム要素）

## レビューのポイント

- 特に見てほしい箇所: input/textarea の例外指定が十分か（他にテキスト選択が必要な要素がないか）
- 判断を仰ぎたい点: 特になし

## 確認済み事項

- [x] ローカルで動作確認（HMR）
- [x] lint通過
