### PR TITLE
feat(timer): 設定をアコーディオン化し、現在時刻を秒までリアルタイム表示

### DIFF
--- a/src/components/multi-ring.tsx
+++ b/src/components/multi-ring.tsx
@@ -68,6 +68,8 @@ type MultiRingProps = {
   readonly onLongPress?: () => void;
   /** アクセシビリティ用のラベル */
   readonly ariaLabel?: string;
+  /** リング全体（button）に渡すクラス。サイズ指定用（未指定時は h-64 w-64） */
+  readonly className?: string;
 };
 
 /**
@@ -89,6 +91,7 @@ export const MultiRing = ({
   onTap,
   onLongPress,
   ariaLabel = "タイマー操作リング",
+  className,
 }: MultiRingProps) => {
   const pointerHandlers = useLongPress(
     {
@@ -100,13 +103,17 @@ export const MultiRing = ({
   return (
     <button
       type="button"
-      className="group cursor-pointer select-none rounded-full outline-none transition-transform duration-150 active:scale-95 focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0a]"
+      className={
+        className
+          ? `group cursor-pointer select-none rounded-full outline-none transition-transform duration-150 active:scale-95 focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0a] ${className}`
+          : "group mx-auto h-64 w-64 cursor-pointer select-none rounded-full outline-none transition-transform duration-150 active:scale-95 focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#0a0a0a]"
+      }
       aria-label={ariaLabel}
       {...pointerHandlers}
     >
       <svg
         viewBox="0 0 200 200"
-        className="mx-auto h-64 w-64 transition-[filter] duration-200 group-hover:drop-shadow-[0_0_12px_rgba(230,0,18,0.3)]"
+        className="h-full w-full transition-[filter] duration-200 group-hover:drop-shadow-[0_0_12px_rgba(230,0,18,0.3)]"
         role="img"
         aria-hidden="true"
       >

--- a/src/components/preset-drawer.tsx
+++ b/src/components/preset-drawer.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { X, ListMusic } from "lucide-react";
+import { X, PanelRightOpen } from "lucide-react";
 import { usePresetStore } from "@/stores/preset-store";
 import { useDrawerStore } from "@/stores/drawer-store";
 import {
@@ -129,7 +129,7 @@ export const PresetDrawer = memo(function PresetDrawer({
           className="fixed right-0 top-1/2 z-40 flex -translate-y-1/2 items-center gap-1.5 rounded-l-lg border border-r-0 border-red-900/30 bg-[#0a0a0a]/90 px-1.5 py-4 backdrop-blur-sm transition-colors hover:bg-neutral-900"
           aria-label="プリセット一覧を開く"
         >
-          <ListMusic className="size-4 text-neutral-400" />
+          <PanelRightOpen className="size-4 text-neutral-400" />
         </button>
       </DrawerTrigger>
 

--- a/src/pages/timer-page.tsx
+++ b/src/pages/timer-page.tsx
@@ -350,9 +350,9 @@ export const TimerPage = ({ presetId, onSwitchPreset }: TimerPageProps) => {
         </button>
       ) : (
         <div className="flex min-h-0 flex-1 flex-col items-center">
-          {/* 折りたたみ時はこのブロックが flex-1 で伸び、リング・時間を大きく表示 */}
+          {/* 折りたたみ時は 100vh の範囲内でリング・時刻を最大表示 */}
           <div className="flex min-h-0 flex-1 flex-col items-center justify-center">
-            {/* マルチリング: 折りたたみ時は最大 min(72vh,400px) で見やすく */}
+            {/* マルチリング: 折りたたみ時は 100vh から凡例・時刻・summary 分を除いた高さで最大表示 */}
             <MultiRing
               totalProgress={totalProgress}
               workProgress={workProgress}
@@ -365,14 +365,14 @@ export const TimerPage = ({ presetId, onSwitchPreset }: TimerPageProps) => {
               className={
                 accordionOpen
                   ? undefined
-                  : "mx-auto h-[min(72vh,400px)] w-[min(72vh,400px)]"
+                  : "mx-auto h-[min(calc(100vh-11rem),92vw)] w-[min(calc(100vh-11rem),92vw)] max-h-[560px] max-w-[560px]"
               }
             />
 
             {/* 凡例（P5: 補助情報は低明度で控えめに） */}
             {legendElement}
 
-            {/* 時間情報: 現在時刻（毎秒更新）・終了予定・残り。折りたたみ時は大きく */}
+            {/* 時間情報: 現在時刻（毎秒更新）・終了予定・残り。折りたたみ時は 100vh 内で大きく */}
             <div
               className={
                 accordionOpen
@@ -384,7 +384,7 @@ export const TimerPage = ({ presetId, onSwitchPreset }: TimerPageProps) => {
                 className={
                   accordionOpen
                     ? "font-mono text-sm tracking-wider text-neutral-400"
-                    : "font-mono text-base tracking-wider text-neutral-400"
+                    : "font-mono text-xl tracking-wider text-neutral-400"
                 }
               >
                 現在 {format(now, "H:mm:ss")}
@@ -394,7 +394,7 @@ export const TimerPage = ({ presetId, onSwitchPreset }: TimerPageProps) => {
                   className={
                     accordionOpen
                       ? "font-mono text-2xl font-black text-white"
-                      : "font-mono text-3xl font-black text-white"
+                      : "font-mono text-5xl font-black text-white"
                   }
                   style={{ letterSpacing: "-0.03em" }}
                 >
@@ -406,7 +406,7 @@ export const TimerPage = ({ presetId, onSwitchPreset }: TimerPageProps) => {
                 className={
                   accordionOpen
                     ? "font-mono text-xs tracking-wider text-neutral-500"
-                    : "font-mono text-sm tracking-wider text-neutral-500"
+                    : "font-mono text-lg tracking-wider text-neutral-500"
                 }
               >
                 残り {formatTime(totalRemainingSec)}


### PR DESCRIPTION
## 変更内容

- ラウンド・フェーズ・BPMを `details`/`summary` でアコーディオン化（折り畳み可能）
- 折りたたみ時は表示エリアを拡大し、リング・終了予定・残り時間を大きく表示
- 終了予定時刻の表示を `H:mm` から `H:mm:ss` に変更
- 現在時刻を「現在 H:mm:ss」で表示し、1秒間隔で更新して秒が進む見た目に

## 技術メモ

- MultiRing に `className` を追加し、親からサイズ指定可能に
- アコーディオン開閉は state で制御し、閉じているときのみ拡大表示
- 現在時刻は `setInterval(1000)` で `now` を更新